### PR TITLE
docs(examples): remove undocumented .text-center class usage

### DIFF
--- a/examples/index.html
+++ b/examples/index.html
@@ -13,8 +13,7 @@
   </head>
   <body>
     <a href="#main" class="skip-link">Skip to main content</a>
-    <!-- Using custom .text-center class for demo purposes - not included in browser-nano-css -->
-    <header class="text-center">
+    <header style="text-align: center">
       <h1 id="welcome">Welcome to Browser Nano CSS</h1>
       <p>A minimal, semantic HTML template powered by a 2KB CSS framework.</p>
     </header>
@@ -245,8 +244,7 @@
       </section>
     </main>
 
-    <!-- Using custom .text-center class for demo purposes - not included in browser-nano-css -->
-    <footer class="text-center">
+    <footer style="text-align: center">
       <nav>
         <ul class="flex" aria-label="Footer navigation">
           <li><a href="#welcome">Welcome</a></li>

--- a/examples/style.css
+++ b/examples/style.css
@@ -1,7 +1,4 @@
 /* Custom example styles - not part of browser-nano-css */
-.text-center {
-  text-align: center;
-}
 
 @media (min-width: 768px) {
   .flex {


### PR DESCRIPTION
### 🛠️ What did you change?

- Removed `.text-center` class usage from `examples/index.html` and replaced with inline `style="text-align: center"`
- Removed `.text-center` class definition from `examples/style.css`
- Applied code formatting with `npm run format`

### 🤔 Why did you make this change?

The examples were using `.text-center` class that is not included in the core framework, creating documentation inconsistency. This contradicts the project's "minimal utility classes" design philosophy where utility classes are avoided to keep CSS small and readable.

### 🧪 How did you test it?

- [x] Verified examples still render correctly with inline styles
- [x] Confirmed no `.text-center` references remain in codebase (grep search)
- [x] Checked that visual consistency is maintained
- [x] Ran `npm run format` to ensure code formatting standards

### ✅ Checklist

- [x] I opened or reviewed a related issue (addressed documentation inconsistency from codebase analysis)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] The change is small and focused (one idea per PR)
- [x] The change follows the project's core design goals:
  - [x] Mobile-first (inline styles work on all devices)
  - [x] Lightweight (removes unused CSS class)
  - [x] Simple HTML and CSS (no JS)
  - [x] Secure and easy to use
  - [x] Follow browser defaults when possible
  - [x] Be **explicit over implicit** when necessary (inline styles are explicit)