### PR TITLE
chore: bump version to 2.0.0-alpha.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "browser-nano-css",
-  "version": "0.6.2",
+  "version": "2.0.0-alpha.1",
   "description": "CSS template",
   "homepage": "https://github.com/sanemat/browser-nano-css#readme",
   "bugs": {


### PR DESCRIPTION
## Summary
- Bump version from 0.6.2 to 2.0.0-alpha.1
- Alpha because CSS implementation has not started yet
- Will move to beta.1 once Phase 1 (CSS) is complete