### PR TITLE
feat: rewrite CSS from scratch for v2

### DIFF
--- a/src/browser-nano.css
+++ b/src/browser-nano.css
@@ -1,303 +1,129 @@
-/* =======================================
-   Reset
-   - Minimal reset for consistent layout
-======================================= */
+:root {
+  --bg: #fff;
+  --text: #000;
+  --accent: var(--text);
+  --font-size-base: 18px;
+  --max-width: 65ch;
+}
+
 *,
 *::before,
 *::after {
-  box-sizing: border-box; /* Include padding and border in width/height */
-  margin: 0; /* Remove default outer space */
-  padding: 0; /* Remove default inner space */
+  box-sizing: border-box;
 }
 
-/* =======================================
-   Design Tokens (Variables)
-   - Centralized and customizable settings
-======================================= */
-:root {
-  /* Typography */
-  --font-family-base: system-ui, sans-serif; /* Modern system font stack */
-  --font-size-base: 1rem; /* 16px */
-  --line-height-base: 1.5; /* Comfortable reading */
-
-  /* Colors: Base */
-  --color-text: #333; /* High readability on white */
-  --color-background: #fff; /* Clean neutral background */
-  --color-link: #0066ff; /* Clear and accessible link color */
-
-  /* Colors: UI element */
-  --color-border: #ccc; /* Light border for inputs and form elements */
-  --color-focus-ring: var(--color-link); /* Used for :focus outline */
-
-  /* Spacing */
-  --spacing-small: 0.5rem; /* Used for buttons, small gaps */
-  --spacing-medium: 1rem; /* Default spacing between blocks */
-
-  /* Radius */
-  --border-radius: 4px; /* Unified corner rounding for buttons and inputs */
-}
-
-/* =======================================
-   Base Styles
-   - Apply variables and basic readability
-======================================= */
 body {
-  font-family: var(--font-family-base);
+  background-color: var(--bg);
+  color: var(--text);
+  font-family: system-ui, sans-serif;
   font-size: var(--font-size-base);
-  line-height: var(--line-height-base);
-  color: var(--color-text);
-  background-color: var(--color-background);
+  line-height: 1.6;
+  margin: 0;
+}
 
-  min-height: 100vh; /* Makes background color fill the screen */
-  word-break: break-word; /* Avoids layout issues with long words */
-  text-size-adjust: 100%; /* Stops mobile Safari from shrinking text */
-  margin: 0; /* Clear top-level reset, matches global reset */
+h1 {
+  font-size: 2em;
+}
+
+h2 {
+  font-size: 1.5em;
+}
+
+h3 {
+  font-size: 1.25em;
+}
+
+h4 {
+  font-size: 1em;
+}
+
+h5 {
+  font-size: 0.875em;
+}
+
+h6 {
+  font-size: 0.75em;
 }
 
 p,
 ul,
 ol {
-  margin-bottom: var(--spacing-medium); /* Clear space between content blocks */
-}
-
-/* Navigation Lists
-   Reset <nav><ul> structure for clean menus */
-nav ul {
-  list-style: none; /* Remove bullets to make the nav menu look clean */
-  padding-left: 0; /* Remove default indent for lists */
-  margin-bottom: var(--spacing-medium); /* Add space below the nav */
-}
-
-/* =======================================
-   Media and Figures
-   - Styling for images and captions
-======================================= */
-
-figure {
-  margin-bottom: var(--spacing-medium); /* Add space below the image block for better layout flow */
-}
-
-figcaption {
-  text-align: center; /* Center the caption under the image to improve readability */
-  font-size: 0.875rem; /* Make the caption text slightly smaller to show it's not main content */
-  color: var(--color-text); /* Use the same text color for consistency */
-  margin-top: var(--spacing-small); /* Add space between image and caption so they don't look crowded */
-}
-
-/* =======================================
-   Components (Optional)
-   - Buttons, forms, tables, etc.
-======================================= */
-
-h1,
-h2,
-h3,
-h4,
-h5,
-h6 {
-  font-weight: bold; /* Make all headings bold for consistency */
-  line-height: 1.25; /* Tighter line spacing for better structure */
-  margin-top: 1em; /* Add space above to separate from previous content */
-  margin-bottom: 0.5em; /* Add space below to separate from following content */
+  margin-block-end: 1rem;
 }
 
 a {
-  color: var(--color-link); /* Clear and readable link color */
-  text-decoration: underline; /* Always underline: important for mobile and accessibility */
-  text-decoration-skip-ink: auto; /* Better looking underline */
+  color: var(--accent);
+  text-decoration: underline;
 }
 
-a:focus {
-  outline: 2px solid var(--color-focus-ring); /* Use strong and consistent color for keyboard focus */
-  outline-offset: 2px; /* Better visibility, avoids overlap with underline */
+code,
+pre {
+  font-family: monospace, monospace;
 }
 
-input,
-textarea,
-select {
-  font: inherit; /* Makes form elements visually match the rest of the UI */
-  color: inherit; /* Ensures consistent text color across components */
-  background-color: var(--color-background); /* Keeps background aligned with site theme */
-  border: 1px solid var(--color-border); /* Adds a clear visual boundary without looking heavy */
-  border-radius: var(--border-radius); /* Softens edges for a modern, friendly appearance */
-  padding: var(--spacing-small); /* Improves tap target size and readability */
-  width: 100%; /* Ensures mobile-first full-width inputs for better UX on small screens */
-  max-width: 100%; /* Prevents layout-breaking overflow in narrow containers */
-  box-sizing: border-box; /* Simplifies layout calculations and prevents unexpected sizing */
-  min-height: 2.5rem; /* Keep form element height stable to prevent CLS */
+pre {
+  overflow-x: auto;
+  padding: 1rem;
 }
 
-textarea {
-  resize: vertical; /* Allow resizing up and down only, to keep layout clean */
+blockquote {
+  border-left: 4px solid currentColor;
+  margin-inline-start: 0;
+  padding-inline-start: 1rem;
 }
 
-input:focus,
-textarea:focus,
-select:focus {
-  outline: 2px solid var(--color-focus-ring); /* Makes focus visible for keyboard and accessibility users */
-  outline-offset: 2px; /* Separates outline from content for better contrast and clarity */
+main {
+  margin-inline: auto;
+  max-width: var(--max-width);
+  padding-inline: 1rem;
 }
 
-label {
-  display: block; /* Makes layout predictable when stacking label + input */
-  margin-bottom: 0.25rem; /* Creates space between label and input for readability */
-  font-weight: bold; /* Helps users quickly scan and understand form structure */
+article {
+  max-width: var(--max-width);
 }
 
-fieldset {
-  border: none; /* Removes outdated browser styling that may clash with the design */
-  margin: 0 0 var(--spacing-medium) 0; /* Adds space between grouped sections */
-  padding: 0; /* Removes default spacing that is often inconsistent across browsers */
-}
-
-legend {
-  font-weight: bold; /* Make the group title clear and readable */
-  margin-bottom: var(--spacing-small); /* Add space between the title and the form fields */
-  display: block; /* Prevent bugs in Safari and improve layout control */
-  min-height: 1.5rem; /* Prevent layout shifts from inconsistent height */
+nav {
+  padding-block: 0.5rem;
 }
 
 button {
-  font: inherit; /* Keeps buttons visually consistent with surrounding text */
-  padding: var(--spacing-small) var(--spacing-medium); /* Makes button easy to tap or click, especially on mobile */
-  background-color: var(--color-text); /* Ensures strong contrast for accessibility */
-  color: var(--color-background); /* Reuses background color token to keep the design balanced */
-  border: none; /* Removes native borders that can look inconsistent */
-  border-radius: var(--border-radius); /* Matches form inputs and adds visual harmony */
-  cursor: pointer; /* Makes it clear that the button is clickable */
-  min-height: 2.5rem; /* Prevent layout shifts when buttons change size */
+  background-color: var(--text);
+  border: none;
+  color: var(--bg);
+  cursor: pointer;
+  font-size: var(--font-size-base);
+  padding: 0.75rem 1.5rem;
 }
 
-button:focus {
-  outline: 2px solid var(--color-focus-ring); /* Use strong and consistent color for keyboard focus */
-  outline-offset: 2px; /* Improves visibility of the focus ring without overlap */
+input,
+select,
+textarea {
+  background-color: var(--bg);
+  border: 1px solid var(--text);
+  color: var(--text);
+  font-size: var(--font-size-base);
+  padding: 0.5rem;
+  width: 100%;
 }
 
-/* =======================================
-   Theme Support (Optional)
-   - Example: Dark Mode
-======================================= */
-/*
+label {
+  display: block;
+  margin-block-end: 0.25rem;
+}
+
+fieldset {
+  border: 1px solid var(--text);
+  padding: 1rem;
+}
+
+table {
+  display: block;
+  overflow-x: auto;
+}
+
 @media (prefers-color-scheme: dark) {
   :root {
-    --color-text: #eee;
-    --color-background: #121212;
+    --bg: #000;
+    --text: #fff;
   }
 }
-*/
-
-/* =======================================
-   Responsive Core Styles
-   - Added for better use on all screen sizes
-======================================= */
-
-/* Container: main column with max width for big screens */
-.container {
-  max-width: 960px; /* Stops content from getting too wide */
-  margin: 0 auto; /* Centers the container */
-  padding: var(--spacing-medium); /* Adds space inside the container */
-}
-
-/* Make sure images, videos, and tables fit on small screens */
-img,
-video,
-table {
-  max-width: 100%; /* Shrinks to fit the screen */
-  height: auto; /* Keeps the original shape */
-  aspect-ratio: auto; /* Reserve space even when width/height is missing */
-}
-
-/* Flex layout: starts stacked, changes to row on wider screens */
-.flex {
-  display: flex; /* Use flexbox */
-  flex-direction: column; /* Stack items for small screens */
-  gap: var(--spacing-medium); /* Add space between items */
-}
-
-@media (min-width: 768px) {
-  /* On big screens, show items side by side */
-  .flex {
-    flex-direction: row;
-  }
-
-  :root {
-    --font-size-base: 1.125rem; /* Bigger text for easier reading */
-  }
-}
-
-/* =======================================
-   Accessibility Support
-   - Respect user preference for reduced motion
-======================================= */
-@media (prefers-reduced-motion: reduce) {
-  * {
-    animation: none !important; /* Turn off animations for users who prefer reduced motion */
-    transition: none !important; /* Turn off transitions to avoid motion effects */
-  }
-}
-
-/* =======================================
-   Accessibility Helpers
-======================================= */
-/*
-  Hides content visually but keeps it available for screen readers.
-  Use this class for accessibility, like skip links or hidden labels.
-*/
-.visually-hidden {
-  position: absolute;
-  width: 1px;
-  height: 1px;
-  padding: 0;
-  margin: -1px;
-  overflow: hidden;
-  clip: rect(0 0 0 0);
-  white-space: nowrap;
-  border: 0;
-}
-
-/*
-  When the user focuses the link (for example, by pressing Tab),
-  show the link so they can see and use it.
-*/
-.focusable:focus {
-  position: static;
-  width: auto;
-  height: auto;
-  margin: var(--spacing-medium);
-  padding: var(--spacing-small) var(--spacing-medium);
-  background: var(--color-text);
-  color: var(--color-background);
-  z-index: 1000;
-  text-decoration: none;
-}
-
-/*
-  Makes a button or link easier to tap on touchscreens.
-  Adds minimum size and sets inline-block to ensure it works with links.
-*/
-.tap-target {
-  display: inline-block;
-  min-width: 48px;
-  min-height: 48px;
-}
-
-/*
-  Skip link for keyboard users.
-  It helps skip repeated content and go directly to the main content.
-*/
-.skip-link {
-  position: absolute;
-  top: -40px;
-  left: 0;
-  background: var(--color-background);
-  color: var(--color-text);
-  padding: var(--spacing-small);
-  z-index: 1000;
-}
-
-.skip-link:focus {
-  top: 0; /* Show when focused */
-}
-
-/* Viewport meta tag (not CSS, but add this to HTML <head>) */
-/* <meta name="viewport" content="width=device-width, initial-scale=1"> */


### PR DESCRIPTION
## Summary
- Complete rewrite of `src/browser-nano.css` for v2 philosophy
- Removes all utility classes (`.container`, `.flex`, `.visually-hidden`, etc.)
- 5 CSS variables only: `--bg`, `--text`, `--accent`, `--font-size-base`, `--max-width`
- `--accent: var(--text)` — follows text color, inverts automatically in dark mode
- Element-based styling only, no classes

## What's included (todo items 3–10)
- CSS variables
- Reset: `box-sizing` only
- Base: `body` font, color, line-height 1.6
- Typography: `h1`–`h6`, `p`/`ul`/`ol`, `a`, `code`, `pre`, `blockquote`
- Structural: `main` (centered, max-width), `article`, `nav`
- App UI: `button`, `input`, `select`, `textarea`, `label`, `fieldset`
- Table: `overflow-x: auto` only
- Dark mode: `prefers-color-scheme: dark`

## Size
583 bytes gzipped (limit: 2048 bytes)