### PR TITLE
feat: add html-validate and update examples content for v2

### DIFF
--- a/.htmlvalidate.json
+++ b/.htmlvalidate.json
@@ -1,0 +1,6 @@
+{
+  "rules": {
+    "doctype-style": ["error", { "style": "lowercase" }],
+    "void-style": ["error", { "style": "selfclose" }]
+  }
+}

--- a/examples/index.html
+++ b/examples/index.html
@@ -18,7 +18,7 @@
         Write correct HTML. Get a usable, readable screen on mobile. Handle your
         own layout. Under 2KB.
       </p>
-      <nav>
+      <nav aria-label="Primary">
         <ul>
           <li><a href="#typography">Typography</a></li>
           <li><a href="#structure">Structure</a></li>
@@ -175,7 +175,7 @@
     </main>
 
     <footer>
-      <nav>
+      <nav aria-label="Footer">
         <ul>
           <li><a href="#typography">Typography</a></li>
           <li><a href="#structure">Structure</a></li>

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "format": "npm run prettier && npm run sort-package-json",
     "format:check": "npm run prettier:check && npm run sort-package-json:check",
     "git:tag": "git tag v$(node -p \"require('./package.json').version\")",
+    "html-validate": "html-validate examples/**/*.html",
     "prettier": "prettier --write .",
     "prettier:check": "prettier --check .",
     "process-css": "postcss src/browser-nano.css -o dist/browser-nano.min.css --map",
@@ -42,7 +43,7 @@
     "size:check": "node tools/size.js check",
     "sort-package-json": "sort-package-json",
     "sort-package-json:check": "sort-package-json --check",
-    "test": "npm run format:check",
+    "test": "npm run format:check && npm run html-validate",
     "watch": "postcss src/browser-nano.css -o dist/browser-nano.min.css --watch"
   },
   "devDependencies": {
@@ -50,6 +51,7 @@
     "conventional-changelog-cli": "^5.0.0",
     "cssnano": "^7.0.6",
     "del-cli": "^6.0.0",
+    "html-validate": "^10.15.0",
     "postcss-cli": "^11.0.1",
     "prettier": "^3.5.3",
     "serve": "^14.2.4",


### PR DESCRIPTION
## Summary
- Add `html-validate` for W3C HTML validation
- `.htmlvalidate.json` — style rules aligned with Prettier output (lowercase doctype, selfclose void elements); semantic/accessibility rules use html-validate defaults
- `npm test` now runs `format:check` + `html-validate`
- Update examples content: v2 tagline, Typography section, simplified form, remove outdated descriptions
- Fix `unique-landmark`: add `aria-label` to both `<nav>` elements
- Clean up `examples/style.css`: remove unused `.flex` rule