### PR TITLE
ci: add v2 branch to CI trigger and dependabot npm updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,5 +3,11 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "weekly" # "daily" or "weekly", "monthly"
+      interval: "weekly"
+    open-pull-requests-limit: 5
+  - package-ecosystem: "npm"
+    directory: "/"
+    target-branch: "v2"
+    schedule:
+      interval: "weekly"
     open-pull-requests-limit: 5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,9 +7,9 @@ on:
         description: "Branch to run tests on"
         required: true
   push:
-    branches: [main]
+    branches: [main, v2]
   pull_request:
-    branches: [main]
+    branches: [main, v2]
 
 permissions:
   contents: read

--- a/design.md
+++ b/design.md
@@ -45,13 +45,13 @@ Five only. No more.
 }
 ```
 
-| Variable           | Default        | Purpose                        |
-| ------------------ | -------------- | ------------------------------ |
-| `--bg`             | `#fff`         | Background color               |
-| `--text`           | `#000`         | Text color                     |
-| `--accent`         | `var(--text)`  | Links and interactive elements |
-| `--font-size-base` | `18px`         | Base font size                 |
-| `--max-width`      | `65ch`         | Max content width              |
+| Variable           | Default       | Purpose                        |
+| ------------------ | ------------- | ------------------------------ |
+| `--bg`             | `#fff`        | Background color               |
+| `--text`           | `#000`        | Text color                     |
+| `--accent`         | `var(--text)` | Links and interactive elements |
+| `--font-size-base` | `18px`        | Base font size                 |
+| `--max-width`      | `65ch`        | Max content width              |
 
 Dark mode swaps `--bg` and `--text`. `--accent` follows `--text` automatically.
 


### PR DESCRIPTION
## Summary
- `ci.yml`: add `v2` to `push` and `pull_request` branch triggers — CI was not running on v2 PRs
- `dependabot.yml`: add npm ecosystem with `target-branch: v2` — npm dependency updates now target v2 during development

## Not changed
- `manual-version-bump.yml`: `base: main` kept as-is — version bumps are manual during v2 phase
- `push-tag-and-release.yml`: stays on `main` only — release fires when v2 merges to main
- `manual-release.yml` / `reusable-release.yml`: no branch dependency, no changes needed