### PR TITLE
feat: add typography styles

### DIFF
--- a/design.md
+++ b/design.md
@@ -69,13 +69,13 @@ Dark mode swaps `--bg` and `--text`. `--accent` follows `--text` automatically.
 
 ### Typography
 
-| Element               | What we do                           |
-| --------------------- | ------------------------------------ |
-| `<h1>`–`<h6>`         | Size scale. Weight: browser default. |
-| `<p>`, `<ul>`, `<ol>` | Spacing, `line-height`               |
-| `<a>`                 | Underline. Color: `var(--accent)`    |
-| `<code>`, `<pre>`     | Monospace, readable, no overflow     |
-| `<blockquote>`        | Left border, spacing                 |
+| Element               | What we do                                                       |
+| --------------------- | ---------------------------------------------------------------- |
+| `<h1>`–`<h6>`         | Size scale. `h5`/`h6` floored at `1em`. Weight: browser default. |
+| `<p>`, `<ul>`, `<ol>` | Spacing, `line-height`                                           |
+| `<a>`                 | Underline. Color: `var(--accent)`                                |
+| `<code>`, `<pre>`     | Monospace, readable, no overflow                                 |
+| `<blockquote>`        | Left border, spacing                                             |
 
 ### App UI
 
@@ -95,6 +95,7 @@ Dark mode swaps `--bg` and `--text`. `--accent` follows `--text` automatically.
 - Base font-size: `18px` — 16px is too small on mobile
 - Line-height: `1.6` — readable on mobile
 - Font-weight: browser defaults only — we do not override `bold`
+- `h5`/`h6` floored at `1em` — smaller than body text breaks mobile readability
 
 ---
 

--- a/design.md
+++ b/design.md
@@ -6,6 +6,8 @@
 
 One strong opinion: **readability on mobile**. We declare colors, font-size, and max-width explicitly — because "readable" is meaningless without owning it. Everything else: we trust the browser.
 
+"Trust the browser" applies only to properties we have not touched. Once we declare a property on an element, we own the consequences — including related properties the browser assumed about our value.
+
 Correct HTML is rewarded with good defaults. No classes needed.
 
 ---

--- a/src/browser-nano.css
+++ b/src/browser-nano.css
@@ -21,6 +21,15 @@ body {
   margin: 0;
 }
 
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+  margin-block: 1.5rem 0.5rem;
+}
+
 h1 {
   font-size: 2em;
 }

--- a/src/browser-nano.css
+++ b/src/browser-nano.css
@@ -38,11 +38,11 @@ h4 {
 }
 
 h5 {
-  font-size: 0.875em;
+  font-size: 1em;
 }
 
 h6 {
-  font-size: 0.75em;
+  font-size: 1em;
 }
 
 p,

--- a/src/browser-nano.css
+++ b/src/browser-nano.css
@@ -20,3 +20,54 @@ body {
   line-height: 1.6;
   margin: 0;
 }
+
+h1 {
+  font-size: 2em;
+}
+
+h2 {
+  font-size: 1.5em;
+}
+
+h3 {
+  font-size: 1.25em;
+}
+
+h4 {
+  font-size: 1em;
+}
+
+h5 {
+  font-size: 0.875em;
+}
+
+h6 {
+  font-size: 0.75em;
+}
+
+p,
+ul,
+ol {
+  margin-block-end: 1rem;
+}
+
+a {
+  color: var(--accent);
+  text-decoration: underline;
+}
+
+code,
+pre {
+  font-family: monospace, monospace;
+}
+
+pre {
+  overflow-x: auto;
+  padding: 1rem;
+}
+
+blockquote {
+  border-left: 4px solid currentColor;
+  margin-inline-start: 0;
+  padding-inline-start: 1rem;
+}


### PR DESCRIPTION
## Summary
Step 2 of v2 CSS — typography.

- \`h1\`–\`h4\`: size scale using \`em\`
- \`h5\`, \`h6\`: floored at \`1em\` (18px) — smaller than body text breaks mobile readability
- \`p\`, \`ul\`, \`ol\`: \`margin-block-end: 1rem\`
- \`a\`: \`color: var(--accent)\`, underline
- \`code\`, \`pre\`: \`font-family: monospace, monospace\`
- \`pre\`: \`overflow-x: auto\`, padding
- \`blockquote\`: left border with \`currentColor\`, no left margin
- \`design.md\`: updated to document h5/h6 floor

**Size:** 385 bytes gzipped