### PR TITLE
chore: set size limit to 999 bytes gzipped

### DIFF
--- a/design.md
+++ b/design.md
@@ -2,7 +2,7 @@
 
 ## Philosophy
 
-> Write correct HTML. Get a usable, readable screen on mobile. Handle your own layout. Under 2KB.
+> Write correct HTML. Get a usable, readable screen on mobile. Handle your own layout. Under 1024 bytes.
 
 One strong opinion: **readability on mobile**. We declare colors, font-size, and max-width explicitly — because "readable" is meaningless without owning it. Everything else: we trust the browser.
 
@@ -117,7 +117,7 @@ Automatic via `prefers-color-scheme: dark`. Swaps `--bg` and `--text`. `--accent
 
 ## Size constraint
 
-Under 2KB gzipped. Non-negotiable. If we exceed the limit, we cut features — we never raise the limit.
+Under 1024 bytes gzipped. Non-negotiable. If we exceed the limit, we cut features — we never raise the limit.
 
 ---
 

--- a/design.md
+++ b/design.md
@@ -2,7 +2,7 @@
 
 ## Philosophy
 
-> Write correct HTML. Get a usable, readable screen on mobile. Handle your own layout. Under 1024 bytes.
+> Write correct HTML. Get a usable, readable screen on mobile. Handle your own layout. Under 1000 bytes.
 
 One strong opinion: **readability on mobile**. We declare colors, font-size, and max-width explicitly — because "readable" is meaningless without owning it. Everything else: we trust the browser.
 
@@ -117,7 +117,7 @@ Automatic via `prefers-color-scheme: dark`. Swaps `--bg` and `--text`. `--accent
 
 ## Size constraint
 
-Under 1024 bytes gzipped. Non-negotiable. If we exceed the limit, we cut features — we never raise the limit.
+Under 1000 bytes gzipped. Non-negotiable. If we exceed the limit, we cut features — we never raise the limit.
 
 ---
 

--- a/design.md
+++ b/design.md
@@ -2,7 +2,7 @@
 
 ## Philosophy
 
-> Write correct HTML. Get a usable, readable screen on mobile. Handle your own layout. Under 1000 bytes.
+> Write correct HTML. Get a usable, readable screen on mobile. Handle your own layout. Under 999 bytes.
 
 One strong opinion: **readability on mobile**. We declare colors, font-size, and max-width explicitly — because "readable" is meaningless without owning it. Everything else: we trust the browser.
 
@@ -117,7 +117,7 @@ Automatic via `prefers-color-scheme: dark`. Swaps `--bg` and `--text`. `--accent
 
 ## Size constraint
 
-Under 1000 bytes gzipped. Non-negotiable. If we exceed the limit, we cut features — we never raise the limit.
+Under 999 bytes gzipped. Non-negotiable. If we exceed the limit, we cut features — we never raise the limit.
 
 ---
 

--- a/tools/size.js
+++ b/tools/size.js
@@ -4,7 +4,7 @@
  *
  * Usage:
  *   node tools/size.js show           # Show gzipped size (default)
- *   node tools/size.js check          # Fail if gzipped size exceeds 1024 bytes
+ *   node tools/size.js check          # Fail if gzipped size exceeds 1000 bytes
  *   node tools/size.js help           # Show usage help
  *
  * This script reads `dist/browser-nano.min.css`, gzips it, and:
@@ -17,7 +17,7 @@ const zlib = require("zlib");
 const path = require("path");
 
 const filePath = path.resolve(__dirname, "../dist/browser-nano.min.css");
-const maxSize = 1024; // 1024 bytes
+const maxSize = 1000; // 1000 bytes
 const mode = (process.argv[2] || "show").toLowerCase();
 
 function showHelp() {
@@ -26,7 +26,7 @@ function showHelp() {
 
 Usage:
   node tools/size.js show     Show gzipped size (default)
-  node tools/size.js check    Fail if gzipped size exceeds 1024 bytes
+  node tools/size.js check    Fail if gzipped size exceeds 1000 bytes
   node tools/size.js help     Show this help message
 `);
 }

--- a/tools/size.js
+++ b/tools/size.js
@@ -4,7 +4,7 @@
  *
  * Usage:
  *   node tools/size.js show           # Show gzipped size (default)
- *   node tools/size.js check          # Fail if gzipped size exceeds 1000 bytes
+ *   node tools/size.js check          # Fail if gzipped size exceeds 999 bytes
  *   node tools/size.js help           # Show usage help
  *
  * This script reads `dist/browser-nano.min.css`, gzips it, and:
@@ -17,7 +17,7 @@ const zlib = require("zlib");
 const path = require("path");
 
 const filePath = path.resolve(__dirname, "../dist/browser-nano.min.css");
-const maxSize = 1000; // 1000 bytes
+const maxSize = 999; // 999 bytes
 const mode = (process.argv[2] || "show").toLowerCase();
 
 function showHelp() {
@@ -26,7 +26,7 @@ function showHelp() {
 
 Usage:
   node tools/size.js show     Show gzipped size (default)
-  node tools/size.js check    Fail if gzipped size exceeds 1000 bytes
+  node tools/size.js check    Fail if gzipped size exceeds 999 bytes
   node tools/size.js help     Show this help message
 `);
 }

--- a/tools/size.js
+++ b/tools/size.js
@@ -4,7 +4,7 @@
  *
  * Usage:
  *   node tools/size.js show           # Show gzipped size (default)
- *   node tools/size.js check          # Fail if gzipped size exceeds 2KB
+ *   node tools/size.js check          # Fail if gzipped size exceeds 1024 bytes
  *   node tools/size.js help           # Show usage help
  *
  * This script reads `dist/browser-nano.min.css`, gzips it, and:
@@ -17,7 +17,7 @@ const zlib = require("zlib");
 const path = require("path");
 
 const filePath = path.resolve(__dirname, "../dist/browser-nano.min.css");
-const maxSize = 2048; // 2KB
+const maxSize = 1024; // 1024 bytes
 const mode = (process.argv[2] || "show").toLowerCase();
 
 function showHelp() {
@@ -26,7 +26,7 @@ function showHelp() {
 
 Usage:
   node tools/size.js show     Show gzipped size (default)
-  node tools/size.js check    Fail if gzipped size exceeds 2KB
+  node tools/size.js check    Fail if gzipped size exceeds 1024 bytes
   node tools/size.js help     Show this help message
 `);
 }


### PR DESCRIPTION
## Summary
- Change size limit from 2048 bytes to 999 bytes
- Current size: 405 bytes — well within the limit
- Update \`tools/size.js\` and \`design.md\`

Under 999 bytes. More impactful than 1000 or 1024.