### PR TITLE
feat: lower heading margin specificity to zero with :where()

### DIFF
--- a/design.md
+++ b/design.md
@@ -84,11 +84,12 @@ Dark mode swaps `--bg` and `--text` via `light-dark()`. `--accent` follows `--te
 
 | Element                             | What we do                                                                                                                                     |
 | ----------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
-| `<button>`                          | Touch-friendly padding, high contrast, cursor, `font-size: var(--font-size-base)`                                                              |
-| `<input>`, `<select>`, `<textarea>` | `width: 100%`, border, `font-size: var(--font-size-base)`                                                                                      |
+| `<button>`                          | Touch-friendly padding, high contrast, cursor. `font: inherit` via reset.                                                                      |
+| `<input>`, `<select>`, `<textarea>` | `width: 100%`, border. `font: inherit` via reset.                                                                                              |
 | `<label>`                           | Display block, tap target                                                                                                                      |
 | `<fieldset>`                        | Grouping, border                                                                                                                               |
 | `<table>`                           | `display: block; overflow-x: auto` — `display: block` is required for `overflow-x` to work on table elements; row/cell formatting is preserved |
+| Checkboxes, radios, range, progress | `accent-color: var(--accent)` on `:root` — no per-element rule needed                                                                          |
 
 ---
 

--- a/src/browser-nano.css
+++ b/src/browser-nano.css
@@ -13,6 +13,13 @@
   box-sizing: border-box;
 }
 
+button,
+input,
+select,
+textarea {
+  font-size: inherit;
+}
+
 body {
   background-color: var(--bg);
   color: var(--text);
@@ -22,12 +29,7 @@ body {
   margin: 0;
 }
 
-h1,
-h2,
-h3,
-h4,
-h5,
-h6 {
+:is(h1, h2, h3, h4, h5, h6) {
   margin-block: 1.5rem 0.5rem;
 }
 
@@ -43,15 +45,7 @@ h3 {
   font-size: 1.25em;
 }
 
-h4 {
-  font-size: 1em;
-}
-
-h5 {
-  font-size: 1em;
-}
-
-h6 {
+:is(h4, h5, h6) {
   font-size: 1em;
 }
 
@@ -101,7 +95,6 @@ button {
   border: none;
   color: var(--bg);
   cursor: pointer;
-  font-size: var(--font-size-base);
   padding: 0.75rem 1.5rem;
 }
 
@@ -111,7 +104,6 @@ textarea {
   background-color: var(--bg);
   border: 1px solid var(--text);
   color: var(--text);
-  font-size: var(--font-size-base);
   padding: 0.5rem;
   width: 100%;
 }

--- a/src/browser-nano.css
+++ b/src/browser-nano.css
@@ -5,6 +5,7 @@
   --accent: var(--text);
   --font-size-base: 18px;
   --max-width: 65ch;
+  accent-color: var(--accent);
 }
 
 *,
@@ -17,7 +18,7 @@ button,
 input,
 select,
 textarea {
-  font-size: inherit;
+  font: inherit;
 }
 
 body {
@@ -29,7 +30,7 @@ body {
   margin: 0;
 }
 
-:is(h1, h2, h3, h4, h5, h6) {
+:where(h1, h2, h3, h4, h5, h6) {
   margin-block: 1.5rem 0.5rem;
 }
 
@@ -91,8 +92,8 @@ nav {
 }
 
 button {
-  background-color: var(--text);
-  border: none;
+  background: var(--text);
+  border: 0;
   color: var(--bg);
   cursor: pointer;
   padding: 0.75rem 1.5rem;
@@ -101,7 +102,7 @@ button {
 input,
 select,
 textarea {
-  background-color: var(--bg);
+  background: var(--bg);
   border: 1px solid var(--text);
   color: var(--text);
   padding: 0.5rem;


### PR DESCRIPTION
## Changes

- `:where(h1–h6)` for `margin-block` — specificity 0, intentionally easier for users to override
- `:is(h4, h5, h6)` groups the `font-size: 1em` floor into one rule (specificity preserved)
- `font: inherit` in reset block for `button`, `input`, `select`, `textarea` — inherits font-family and line-height too, not just font-size
- `accent-color: var(--accent)` on `:root` — styles checkbox, radio, range, progress without per-element rules
- `background` shorthand and `border: 0` for `button`

## Why

**`:where()` for heading margins** — this is an intentional behavior change. `:where()` has specificity 0, so users can override heading `margin-block` with a plain element selector (`h1 { margin-block: 0; }`) regardless of load order. This fits the project's "handle your own layout" philosophy — the library provides readable defaults, not opinions users have to fight.

`:is()` is used for `h4–h6` font-size because that rule exists to correct browser defaults (h5/h6 are smaller than body text), not as a layout default users should routinely override.

**`font: inherit`** — browser UA stylesheets set `font-size: medium` and a different `font-family` on form elements, breaking inheritance. `font: inherit` restores full font inheritance in one reset declaration.

**`accent-color`** — Chrome 93+, Firefox 92+, Safari 15.4+. Covers native form controls the CSS cannot otherwise reach cleanly.

## Size

600 bytes gzipped.