### PR TITLE
fix: exclude checkbox and radio from input width/border styles

### DIFF
--- a/design.md
+++ b/design.md
@@ -85,7 +85,7 @@ Dark mode swaps `--bg` and `--text` via `light-dark()`. `--accent` follows `--te
 | Element                             | What we do                                                                                                                                     |
 | ----------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
 | `<button>`                          | Touch-friendly padding, high contrast, cursor. `font: inherit` via reset.                                                                      |
-| `<input>`, `<select>`, `<textarea>` | `width: 100%`, border. `font: inherit` via reset.                                                                                              |
+| `<input>`, `<select>`, `<textarea>` | `width: 100%`, border. `font: inherit` via reset. Excludes `checkbox`/`radio` (styled via `accent-color`).                                     |
 | `<label>`                           | Display block, tap target                                                                                                                      |
 | `<fieldset>`                        | Grouping, border                                                                                                                               |
 | `<table>`                           | `display: block; overflow-x: auto` — `display: block` is required for `overflow-x` to work on table elements; row/cell formatting is preserved |

--- a/src/browser-nano.css
+++ b/src/browser-nano.css
@@ -99,7 +99,7 @@ button {
   padding: 0.75rem 1.5rem;
 }
 
-input,
+input:not([type="checkbox"]):not([type="radio"]),
 select,
 textarea {
   background: var(--bg);


### PR DESCRIPTION
## Summary

- `input` selector was applying `width: 100%`, `border`, `background`, `color`, and `padding` to all input types
- This caused checkbox and radio inputs to render incorrectly (giant boxes, wrong borders)
- Fix: use `:not([type="checkbox"]):not([type="radio"])` to exclude them
- Checkbox/radio are already styled via `accent-color: var(--accent)` on `:root` — no further rule needed

Addresses a reviewer comment from PR #163.

## Test plan

- [ ] Verify checkboxes and radios render at native size with no unexpected border/background
- [ ] Verify text inputs, email, password, number, etc. still get `width: 100%` and border styles
- [ ] Size check: 627 bytes gzipped (within 999 byte limit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)