### PR TITLE
fix: use margin-inline: 0 on blockquote to clear asymmetric UA margins

### DIFF
--- a/src/browser-nano.css
+++ b/src/browser-nano.css
@@ -73,7 +73,7 @@ pre {
 
 blockquote {
   border-left: 4px solid currentColor;
-  margin-inline-start: 0;
+  margin-inline: 0;
   padding-inline-start: 1rem;
 }
 


### PR DESCRIPTION
## Summary

- UA sets `margin-inline: 40px` on `blockquote` (both sides)
- Previous rule only reset `margin-inline-start: 0`, leaving `margin-inline-end` at 40px → asymmetric indentation
- Fix: `margin-inline: 0` clears both sides consistently
- Side effect: 1 byte shorter

## Not taken: `p/ul/ol` margin-block-start

Reviewer also suggested setting both `margin-block-start` and `margin-block-end` on `p`, `ul`, `ol`. Decided against:
- `margin-block-start` and `margin-block-end` are independent logical properties — touching one does not mean we "own" the other
- Intent is "space after elements", not a full margin reset
- UA `margin-block-start: 1em` on `p` is acceptable and predictable

## Test plan

- [ ] Verify `blockquote` has no left or right indentation (only the left border from `border-left`)
- [ ] Size check: 600 bytes gzipped (within 999 byte limit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)