### PR TITLE
fix(examples): add padding-inline to header and footer

### DIFF
--- a/examples/style.css
+++ b/examples/style.css
@@ -1,1 +1,6 @@
 /* Custom example styles - not part of browser-nano-css */
+
+header,
+footer {
+  padding-inline: 1rem;
+}


### PR DESCRIPTION
## Summary

- `header` and `footer` had no horizontal padding, making content flush against the screen edge on mobile
- Added `padding-inline: 1rem` to `examples/style.css` to match `main`'s inline padding
- `browser-nano.css` is intentionally unchanged — the library does not style `header`/`footer` ("handle your own layout")

`examples/style.css` exists for site-specific styles and serves as a pattern users can copy.

## Test plan

- [ ] Verify `header` and `footer` content has the same left/right spacing as `main` content
- [ ] Verify `browser-nano.css` is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)