### PR TITLE
ci: use Node 24 with registry-url for npm Trusted Publishers

### DIFF
--- a/.github/workflows/reusable-release.yml
+++ b/.github/workflows/reusable-release.yml
@@ -35,7 +35,8 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
-          node-version: "22"
+          node-version: "24"
+          registry-url: "https://registry.npmjs.org"
 
       - name: Install dependencies
         run: npm i

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "browser-nano-css",
-  "version": "2.0.0-beta.4",
+  "version": "2.0.0-beta.5",
   "description": "CSS template",
   "homepage": "https://github.com/sanemat/browser-nano-css#readme",
   "bugs": {


### PR DESCRIPTION
## Summary

- Node 24 ships with npm 11+ which supports OIDC-based authentication (Trusted Publishers) natively
- `registry-url` is kept so `setup-node` correctly configures the npm registry
- `NODE_AUTH_TOKEN` is not set — npm 11 uses OIDC automatically when Trusted Publisher is configured
- package.json bumped to `2.0.0-beta.5`

## Test plan

- [ ] Run Manual Release workflow with tag `v2.0.0-beta.5`
- [ ] Verify npm publish succeeds without `NODE_AUTH_TOKEN`

🤖 Generated with [Claude Code](https://claude.com/claude-code)