### PR TITLE
feat(examples): style site header and footer with body > selectors

### DIFF
--- a/examples/style.css
+++ b/examples/style.css
@@ -1,6 +1,21 @@
 /* Custom example styles - not part of browser-nano-css */
 
-header,
-footer {
+body > header,
+body > footer {
   padding-inline: 1rem;
+  padding-block: 1rem;
+}
+
+body > header nav ul,
+body > footer nav ul {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  list-style: none;
+  padding: 0;
+}
+
+body > footer {
+  border-block-start: 1px solid currentColor;
+  margin-block-start: 2rem;
 }


### PR DESCRIPTION
## Summary

- Replaced `header, footer` with `body > header, body > footer` to target only the site-level elements
- `body > header` and `body > footer` are intentional: avoids styling `<header>` or `<footer>` inside `<article>` or `<section>`
- Added `padding-block: 1rem` for vertical spacing
- Nav links displayed horizontally with `display: flex` and `gap`
- Footer gets `border-block-start` separator and `margin-block-start` breathing room

Note: `browser-nano.css` avoids context-aware selectors by design. `examples/style.css` is user code where `body >` is the correct and explicit pattern.

## Test plan

- [ ] Verify site header and footer have consistent padding on all sides
- [ ] Verify nav links appear horizontally in header and footer
- [ ] Verify footer has a top border separating it from main content
- [ ] Verify `<header>` inside `<article>` is NOT affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)