### PR TITLE
fix: remove input rule, trust browser for input styling

### DIFF
--- a/design.md
+++ b/design.md
@@ -85,7 +85,7 @@ Dark mode swaps `--bg` and `--text` via `light-dark()`. `--accent` follows `--te
 | Element                             | What we do                                                                                                                                     |
 | ----------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
 | `<button>`                          | Touch-friendly padding, high contrast, cursor. `font: inherit` via reset.                                                                      |
-| `<input>`, `<select>`, `<textarea>` | `width: 100%`, border. `font: inherit` via reset. Excludes `checkbox`/`radio` (styled via `accent-color`).                                     |
+| `<select>`, `<textarea>`            | `width: 100%`, border. `font: inherit` via reset.                                                                                              |
 | `<label>`                           | Display block, tap target                                                                                                                      |
 | `<fieldset>`                        | Grouping, border                                                                                                                               |
 | `<table>`                           | `display: block; overflow-x: auto` — `display: block` is required for `overflow-x` to work on table elements; row/cell formatting is preserved |

--- a/readme.md
+++ b/readme.md
@@ -57,7 +57,7 @@ Override any variable in your own stylesheet:
 
 - Typography: `h1`–`h6`, `p`, `ul`, `ol`, `a`, `code`, `pre`, `blockquote`
 - Structure: `main`, `article`, `nav`
-- Forms: `button`, `input`, `select`, `textarea`, `label`, `fieldset`
+- Forms: `button`, `select`, `textarea`, `label`, `fieldset`
 - Table: `overflow-x: auto` for mobile scroll
 
 ## What does NOT get styled

--- a/src/browser-nano.css
+++ b/src/browser-nano.css
@@ -99,7 +99,6 @@ button {
   padding: 0.75rem 1.5rem;
 }
 
-input:not([type="checkbox"]):not([type="radio"]),
 select,
 textarea {
   background: var(--bg);


### PR DESCRIPTION
## Summary

- Remove `input` from the `select, textarea` styling rule
- `input` is too polymorphic — `type=color`, `type=file`, `type=date`, `type=range`, `type=submit`, etc. all behave differently
- Applying `width: 100%`, `border`, `background` causes real visual harm on non-text input types
- Trust the browser for `input`; only style `select` and `textarea`
- Update `design.md` and `readme.md` to reflect the change

## Test plan

- [ ] `select` and `textarea` still get `width: 100%`, border, background styling
- [ ] `input[type="text"]` falls back to browser default (expected)
- [ ] `input[type="color"]` renders correctly as a color picker
- [ ] `input[type="file"]` renders correctly as a file picker
- [ ] `input[type="range"]` renders correctly as a range slider
- [ ] Build passes size check

🤖 Generated with [Claude Code](https://claude.com/claude-code)