### PR TITLE
feat: set --accent to blue, add a:visited rule

### DIFF
--- a/design.md
+++ b/design.md
@@ -76,7 +76,7 @@ Dark mode swaps `--bg` and `--text` via `light-dark()`. `--accent` uses blue in 
 | --------------------- | ---------------------------------------------------------------------------------------------------- |
 | `<h1>`–`<h6>`         | Size scale. `h4`/`h5`/`h6` floored at `1em`. `margin-block: 1.5rem 0.5rem`. Weight: browser default. |
 | `<p>`, `<ul>`, `<ol>` | `margin-block-end: 1rem`. `line-height` inherited from `body`.                                       |
-| `<a>`                 | Underline. Color: `var(--accent)`                                                                    |
+| `<a>`                 | Underline. Color: `var(--accent)`. Visited: purple (hardcoded, see CSS Variables)                    |
 | `<code>`, `<pre>`     | Monospace, readable, no overflow                                                                     |
 | `<blockquote>`        | Left border, spacing                                                                                 |
 

--- a/design.md
+++ b/design.md
@@ -42,21 +42,21 @@ Five only. No more.
   color-scheme: light dark;
   --bg: light-dark(#fff, #000);
   --text: light-dark(#000, #fff);
-  --accent: var(--text);
+  --accent: light-dark(#0645d2, #8ab4f8);
   --font-size-base: 18px;
   --max-width: 65ch;
 }
 ```
 
-| Variable           | Default                  | Purpose                        |
-| ------------------ | ------------------------ | ------------------------------ |
-| `--bg`             | `light-dark(#fff, #000)` | Background color               |
-| `--text`           | `light-dark(#000, #fff)` | Text color                     |
-| `--accent`         | `var(--text)`            | Links and interactive elements |
-| `--font-size-base` | `18px`                   | Base font size                 |
-| `--max-width`      | `65ch`                   | Max content width              |
+| Variable           | Default                        | Purpose                        |
+| ------------------ | ------------------------------ | ------------------------------ |
+| `--bg`             | `light-dark(#fff, #000)`       | Background color               |
+| `--text`           | `light-dark(#000, #fff)`       | Text color                     |
+| `--accent`         | `light-dark(#0645d2, #8ab4f8)` | Links and interactive elements |
+| `--font-size-base` | `18px`                         | Base font size                 |
+| `--max-width`      | `65ch`                         | Max content width              |
 
-Dark mode swaps `--bg` and `--text` via `light-dark()`. `--accent` follows `--text` automatically. Users who override `--bg` or `--text` can also use `light-dark()` for their custom values.
+Dark mode swaps `--bg` and `--text` via `light-dark()`. `--accent` uses blue in light mode and a lighter blue in dark mode, both meeting WCAG AAA contrast. Visited links use a hardcoded purple (`light-dark(#551a8b, #c58af9)`) — no variable, override with `a:visited { color: ... }` if needed.
 
 ---
 
@@ -113,9 +113,9 @@ Dark mode swaps `--bg` and `--text` via `light-dark()`. `--accent` follows `--te
 
 ## Dark mode
 
-Automatic via `color-scheme: light dark` and `light-dark()`. No `@media` block needed. `--accent` follows `--text` automatically — no extra rule needed. No opt-in needed.
+Automatic via `color-scheme: light dark` and `light-dark()`. No `@media` block needed. No opt-in needed.
 
-Users who override `--bg` or `--text` can use `light-dark()` for their custom values to get the same automatic swap.
+Users who override any variable can use `light-dark()` for their custom values to get the same automatic swap.
 
 ---
 

--- a/design.md
+++ b/design.md
@@ -72,13 +72,13 @@ Dark mode swaps `--bg` and `--text` via `light-dark()`. `--accent` uses blue in 
 
 ### Typography
 
-| Element               | What we do                                                                                      |
-| --------------------- | ----------------------------------------------------------------------------------------------- |
-| `<h1>`–`<h6>`         | Size scale. `h5`/`h6` floored at `1em`. `margin-block: 1.5rem 0.5rem`. Weight: browser default. |
-| `<p>`, `<ul>`, `<ol>` | `margin-block-end: 1rem`. `line-height` inherited from `body`.                                  |
-| `<a>`                 | Underline. Color: `var(--accent)`                                                               |
-| `<code>`, `<pre>`     | Monospace, readable, no overflow                                                                |
-| `<blockquote>`        | Left border, spacing                                                                            |
+| Element               | What we do                                                                                           |
+| --------------------- | ---------------------------------------------------------------------------------------------------- |
+| `<h1>`–`<h6>`         | Size scale. `h4`/`h5`/`h6` floored at `1em`. `margin-block: 1.5rem 0.5rem`. Weight: browser default. |
+| `<p>`, `<ul>`, `<ol>` | `margin-block-end: 1rem`. `line-height` inherited from `body`.                                       |
+| `<a>`                 | Underline. Color: `var(--accent)`                                                                    |
+| `<code>`, `<pre>`     | Monospace, readable, no overflow                                                                     |
+| `<blockquote>`        | Left border, spacing                                                                                 |
 
 ### App UI
 
@@ -99,7 +99,7 @@ Dark mode swaps `--bg` and `--text` via `light-dark()`. `--accent` uses blue in 
 - Base font-size: `18px` — 16px is too small on mobile
 - Line-height: `1.6` — readable on mobile
 - Font-weight: browser defaults only — we do not override `bold`
-- `h5`/`h6` floored at `1em` — smaller than body text breaks mobile readability
+- `h4`/`h5`/`h6` floored at `1em` — smaller than body text breaks mobile readability
 
 ---
 

--- a/examples/index.html
+++ b/examples/index.html
@@ -65,7 +65,7 @@
         <pre><code>:root {
   --bg: #fff;
   --text: #000;
-  --accent: var(--text);
+  --accent: light-dark(#0645d2, #8ab4f8);
   --font-size-base: 18px;
   --max-width: 65ch;
 }</code></pre>

--- a/readme.md
+++ b/readme.md
@@ -39,7 +39,7 @@ npm install browser-nano-css
 :root {
   --bg: light-dark(#fff, #000);
   --text: light-dark(#000, #fff);
-  --accent: var(--text);
+  --accent: light-dark(#0645d2, #8ab4f8);
   --font-size-base: 18px;
   --max-width: 65ch;
 }

--- a/readme.md
+++ b/readme.md
@@ -51,6 +51,9 @@ Override any variable in your own stylesheet:
 :root {
   --accent: #0066cc;
 }
+a:visited {
+  color: #551a8b; /* match your theme */
+}
 ```
 
 ## What gets styled

--- a/src/browser-nano.css
+++ b/src/browser-nano.css
@@ -2,7 +2,7 @@
   color-scheme: light dark;
   --bg: light-dark(#fff, #000);
   --text: light-dark(#000, #fff);
-  --accent: var(--text);
+  --accent: light-dark(#0645d2, #8ab4f8);
   --font-size-base: 18px;
   --max-width: 65ch;
   accent-color: var(--accent);
@@ -59,6 +59,10 @@ ol {
 a {
   color: var(--accent);
   text-decoration: underline;
+}
+
+a:visited {
+  color: light-dark(#551a8b, #c58af9);
 }
 
 code,


### PR DESCRIPTION
## Summary

- Change \`--accent\` default from \`var(--text)\` to \`light-dark(#0645d2, #8ab4f8)\`
- Add \`a:visited { color: light-dark(#551a8b, #c58af9); }\` to restore visited link distinction
- Update \`design.md\`, \`readme.md\`, and \`examples/index.html\` to reflect the new defaults

## Why

Previously \`--accent: var(--text)\` made links the same color as normal text — only underline for distinction. Also, styling \`a { color: var(--accent) }\` overrides the browser's default \`a:visited\` purple, so visited links lost their visual distinction too.

## Decisions

- Blue (\`#0645d2\` / \`#8ab4f8\`): both meet WCAG AAA contrast against their respective backgrounds
- Visited purple is hardcoded, not a variable — keeps the 5-variable limit. Override with \`a:visited { color: ... }\` if needed
- No 6th CSS variable added

Closes #173

## Test plan

- [ ] Unvisited links are blue in light mode, lighter blue in dark mode
- [ ] Visited links are purple in light mode, lighter purple in dark mode
- [ ] \`accent-color\` on checkboxes/radios shows blue instead of black
- [ ] Build passes size check

🤖 Generated with [Claude Code](https://claude.com/claude-code)