### PR TITLE
feat: add input allowlist for text-like types

### DIFF
--- a/design.md
+++ b/design.md
@@ -85,7 +85,8 @@ Dark mode swaps `--bg` and `--text` via `light-dark()`. `--accent` uses blue in 
 | Element                             | What we do                                                                                                                                     |
 | ----------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
 | `<button>`                          | Touch-friendly padding, high contrast, cursor. `font: inherit` via reset.                                                                      |
-| `<select>`, `<textarea>`            | `width: 100%`, border. `font: inherit` via reset.                                                                                              |
+| `<input>` (text-like types)         | `width: 100%`, border, theme colors. Types: `text`, `email`, `password`, `search`, `url`, `tel`, `number`, no-type. `font: inherit` via reset. |
+| `<select>`, `<textarea>`            | `width: 100%`, border, theme colors. `font: inherit` via reset.                                                                                |
 | `<label>`                           | Display block, tap target                                                                                                                      |
 | `<fieldset>`                        | Grouping, border                                                                                                                               |
 | `<table>`                           | `display: block; overflow-x: auto` — `display: block` is required for `overflow-x` to work on table elements; row/cell formatting is preserved |

--- a/readme.md
+++ b/readme.md
@@ -60,7 +60,7 @@ a:visited {
 
 - Typography: `h1`–`h6`, `p`, `ul`, `ol`, `a`, `code`, `pre`, `blockquote`
 - Structure: `main`, `article`, `nav`
-- Forms: `button`, `select`, `textarea`, `label`, `fieldset`
+- Forms: `button`, `input` (text-like types), `select`, `textarea`, `label`, `fieldset`
 - Table: `overflow-x: auto` for mobile scroll
 
 ## What does NOT get styled

--- a/src/browser-nano.css
+++ b/src/browser-nano.css
@@ -111,12 +111,7 @@ input:is(
   [type="search"],
   [type="url"],
   [type="tel"],
-  [type="number"],
-  [type="date"],
-  [type="time"],
-  [type="datetime-local"],
-  [type="month"],
-  [type="week"]
+  [type="number"]
 ),
 select,
 textarea {

--- a/src/browser-nano.css
+++ b/src/browser-nano.css
@@ -103,6 +103,21 @@ button {
   padding: 0.75rem 1.5rem;
 }
 
+input:is(
+  :not([type]),
+  [type="text"],
+  [type="email"],
+  [type="password"],
+  [type="search"],
+  [type="url"],
+  [type="tel"],
+  [type="number"],
+  [type="date"],
+  [type="time"],
+  [type="datetime-local"],
+  [type="month"],
+  [type="week"]
+),
 select,
 textarea {
   background: var(--bg);


### PR DESCRIPTION
## Summary

Add explicit allowlist for keyboard text-entry \`<input>\` types to receive \`background\`, \`border\`, \`color\`, \`padding\`, and \`width: 100%\` styling.

## Why

PR #172 removed all \`input\` width/border rules to trust the browser. However, leaving \`<input type="text">\` unstyled while \`<select>\` and \`<textarea>\` are styled creates visual inconsistency within forms — especially on mobile where browser defaults for text inputs feel broken.

Picker-style inputs (\`date\`, \`time\`, \`datetime-local\`, \`month\`, \`week\`) are excluded — their browser-native UI should not be overridden.

## Allowlist

```css
input:is(
  :not([type]),
  [type="text"],
  [type="email"],
  [type="password"],
  [type="search"],
  [type="url"],
  [type="tel"],
  [type="number"]
)
```

- `:not([type])` — covers \`<input>\` with no type attribute (defaults to text)
- Excludes: \`checkbox\`, \`radio\`, \`range\`, \`file\`, \`submit\`, \`button\`, \`reset\`, \`image\`, \`hidden\`, \`color\`, \`date\`, \`time\`, \`datetime-local\`, \`month\`, \`week\`

## Size

| | gzipped |
|---|---|
| Before (no input rules) | 633 bytes |
| After (allowlist) | 687 bytes |
| Limit | 999 bytes |

+54 bytes, within limit.

## Test plan

- [ ] \`<input type="text">\` gets border, full width, theme colors
- [ ] \`<input type="email">\`, \`type="password"\`, \`type="search"\`, \`type="url"\`, \`type="tel"\`, \`type="number"\` same
- [ ] \`<input>\` with no type attribute same
- [ ] \`<input type="date">\`, \`type="time"\`, \`type="datetime-local"\` — NOT affected (browser native UI preserved)
- [ ] \`<input type="checkbox">\`, \`type="radio"\`, \`type="range"\` — NOT affected
- [ ] Build passes size check

🤖 Generated with [Claude Code](https://claude.com/claude-code)