### PR TITLE
feat: add :focus-visible outline using --accent

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,4 @@
-## [Unreleased]
+# [Unreleased]
 
 ### Features
 

--- a/changelog.md
+++ b/changelog.md
@@ -2,7 +2,7 @@
 
 ### Features
 
-- **focus:** `:focus-visible` outline using `var(--accent)` — keyboard navigation visible, mouse unaffected ([#180](https://github.com/sanemat/browser-nano-css/issues/180))
+- **focus:** `:focus-visible` outline using `var(--accent)` — keyboard focus indicator ([#180](https://github.com/sanemat/browser-nano-css/issues/180))
 
 # [2.0.0](https://github.com/sanemat/browser-nano-css/compare/v2.0.0-beta.8...v2.0.0) (2026-05-06)
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,9 @@
+## [Unreleased]
+
+### Features
+
+- **focus:** `:focus-visible` outline using `var(--accent)` — keyboard navigation visible, mouse unaffected ([#180](https://github.com/sanemat/browser-nano-css/issues/180))
+
 # [2.0.0](https://github.com/sanemat/browser-nano-css/compare/v2.0.0-beta.8...v2.0.0) (2026-05-06)
 
 ### Features

--- a/design.md
+++ b/design.md
@@ -83,16 +83,16 @@ Dark mode swaps `--bg` and `--text` via `light-dark()`. `--accent` uses blue in 
 
 ### App UI
 
-| Element                                                 | What we do                                                                                                                                     |
-| ------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
-| `<button>`                                              | Touch-friendly padding, high contrast, cursor. `font: inherit` via reset.                                                                      |
-| `<input>` (text-like types)                             | `width: 100%`, border, theme colors. Types: `text`, `email`, `password`, `search`, `url`, `tel`, `number`, no-type. `font: inherit` via reset. |
-| `<select>`, `<textarea>`                                | `width: 100%`, border, theme colors. `font: inherit` via reset.                                                                                |
-| `<label>`                                               | Display block, tap target                                                                                                                      |
-| `<fieldset>`                                            | Grouping, border                                                                                                                               |
-| `<table>`                                               | `display: block; overflow-x: auto` — `display: block` is required for `overflow-x` to work on table elements; row/cell formatting is preserved |
-| Checkboxes, radios, range, progress                     | `accent-color: var(--accent)` on `:root` — no per-element rule needed                                                                          |
-| `:is(a, button, input, select, textarea):focus-visible` | `outline: 2px solid var(--accent); outline-offset: 2px` — keyboard focus indicator                                                             |
+| Element                                                    | What we do                                                                                                                                     |
+| ---------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
+| `<button>`                                                 | Touch-friendly padding, high contrast, cursor. `font: inherit` via reset.                                                                      |
+| `<input>` (text-like types)                                | `width: 100%`, border, theme colors. Types: `text`, `email`, `password`, `search`, `url`, `tel`, `number`, no-type. `font: inherit` via reset. |
+| `<select>`, `<textarea>`                                   | `width: 100%`, border, theme colors. `font: inherit` via reset.                                                                                |
+| `<label>`                                                  | Display block, tap target                                                                                                                      |
+| `<fieldset>`                                               | Grouping, border                                                                                                                               |
+| `<table>`                                                  | `display: block; overflow-x: auto` — `display: block` is required for `overflow-x` to work on table elements; row/cell formatting is preserved |
+| Checkboxes, radios, range, progress                        | `accent-color: var(--accent)` on `:root` — no per-element rule needed                                                                          |
+| `:where(a, button, input, select, textarea):focus-visible` | `outline: 2px solid var(--accent); outline-offset: 2px` — keyboard focus indicator; `input` covers all types, not just text-like               |
 
 ---
 

--- a/design.md
+++ b/design.md
@@ -83,16 +83,16 @@ Dark mode swaps `--bg` and `--text` via `light-dark()`. `--accent` uses blue in 
 
 ### App UI
 
-| Element                             | What we do                                                                                                                                     |
-| ----------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
-| `<button>`                          | Touch-friendly padding, high contrast, cursor. `font: inherit` via reset.                                                                      |
-| `<input>` (text-like types)         | `width: 100%`, border, theme colors. Types: `text`, `email`, `password`, `search`, `url`, `tel`, `number`, no-type. `font: inherit` via reset. |
-| `<select>`, `<textarea>`            | `width: 100%`, border, theme colors. `font: inherit` via reset.                                                                                |
-| `<label>`                           | Display block, tap target                                                                                                                      |
-| `<fieldset>`                        | Grouping, border                                                                                                                               |
-| `<table>`                           | `display: block; overflow-x: auto` — `display: block` is required for `overflow-x` to work on table elements; row/cell formatting is preserved |
-| Checkboxes, radios, range, progress | `accent-color: var(--accent)` on `:root` — no per-element rule needed                                                                          |
-| `:focus-visible`                    | `outline: 2px solid var(--accent); outline-offset: 2px` — keyboard focus visible, mouse unaffected                                             |
+| Element                                                 | What we do                                                                                                                                     |
+| ------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
+| `<button>`                                              | Touch-friendly padding, high contrast, cursor. `font: inherit` via reset.                                                                      |
+| `<input>` (text-like types)                             | `width: 100%`, border, theme colors. Types: `text`, `email`, `password`, `search`, `url`, `tel`, `number`, no-type. `font: inherit` via reset. |
+| `<select>`, `<textarea>`                                | `width: 100%`, border, theme colors. `font: inherit` via reset.                                                                                |
+| `<label>`                                               | Display block, tap target                                                                                                                      |
+| `<fieldset>`                                            | Grouping, border                                                                                                                               |
+| `<table>`                                               | `display: block; overflow-x: auto` — `display: block` is required for `overflow-x` to work on table elements; row/cell formatting is preserved |
+| Checkboxes, radios, range, progress                     | `accent-color: var(--accent)` on `:root` — no per-element rule needed                                                                          |
+| `:is(a, button, input, select, textarea):focus-visible` | `outline: 2px solid var(--accent); outline-offset: 2px` — keyboard focus indicator                                                             |
 
 ---
 

--- a/design.md
+++ b/design.md
@@ -20,6 +20,7 @@ Correct HTML is rewarded with good defaults. No classes needed.
 - Respect `prefers-color-scheme` automatically
 - Style key semantic HTML elements
 - Style mobile form UI elements
+- Visible focus indicator for keyboard navigation (`:focus-visible`)
 
 ## What we do NOT do
 
@@ -91,6 +92,7 @@ Dark mode swaps `--bg` and `--text` via `light-dark()`. `--accent` uses blue in 
 | `<fieldset>`                        | Grouping, border                                                                                                                               |
 | `<table>`                           | `display: block; overflow-x: auto` — `display: block` is required for `overflow-x` to work on table elements; row/cell formatting is preserved |
 | Checkboxes, radios, range, progress | `accent-color: var(--accent)` on `:root` — no per-element rule needed                                                                          |
+| `:focus-visible`                    | `outline: 2px solid var(--accent); outline-offset: 2px` — keyboard focus visible, mouse unaffected                                             |
 
 ---
 

--- a/readme.md
+++ b/readme.md
@@ -62,6 +62,7 @@ a:visited {
 - Structure: `main`, `article`, `nav`
 - Forms: `button`, `input` (text-like types), `select`, `textarea`, `label`, `fieldset`
 - Table: `overflow-x: auto` for mobile scroll
+- Focus: `:focus-visible` keyboard focus indicator using `--accent`
 
 ## What does NOT get styled
 

--- a/readme.md
+++ b/readme.md
@@ -62,7 +62,7 @@ a:visited {
 - Structure: `main`, `article`, `nav`
 - Forms: `button`, `input` (text-like types), `select`, `textarea`, `label`, `fieldset`
 - Table: `overflow-x: auto` for mobile scroll
-- Focus: `:focus-visible` keyboard focus indicator using `--accent`
+- Focus: `:focus-visible` keyboard focus indicator using `--accent` — applies to all `<input>` types, not just text-like
 
 ## What does NOT get styled
 

--- a/src/browser-nano.css
+++ b/src/browser-nano.css
@@ -14,6 +14,11 @@
   box-sizing: border-box;
 }
 
+:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
 button,
 input,
 select,

--- a/src/browser-nano.css
+++ b/src/browser-nano.css
@@ -14,7 +14,7 @@
   box-sizing: border-box;
 }
 
-:focus-visible {
+:is(a, button, input, select, textarea):focus-visible {
   outline: 2px solid var(--accent);
   outline-offset: 2px;
 }

--- a/src/browser-nano.css
+++ b/src/browser-nano.css
@@ -14,7 +14,7 @@
   box-sizing: border-box;
 }
 
-:is(a, button, input, select, textarea):focus-visible {
+:where(a, button, input, select, textarea):focus-visible {
   outline: 2px solid var(--accent);
   outline-offset: 2px;
 }


### PR DESCRIPTION
## Summary

- Add `:where(a, button, input, select, textarea):focus-visible { outline: 2px solid var(--accent); outline-offset: 2px }` for keyboard navigation
- Uses existing `--accent` variable — visually consistent with links and interactive elements
- Scoped to styled elements only — out-of-scope elements like `<summary>` are unaffected
- Zero specificity via `:where()` — easy to override with any element selector

## Motivation

We already restyle `<button>`, `<input>`, `<select>`. Once we own interactive element appearance, focus visibility is our responsibility too. WCAG AAA contrast is a stated goal; visible focus indicators (WCAG 2.4.7) are part of the same commitment.

Current gzipped size: 687 → 723 bytes (well within 999-byte limit).

Closes #180

## Test plan

- [ ] Tab through a page — focus ring appears on interactive elements
- [ ] Dark mode — outline uses `--accent` (lighter blue), remains visible
- [ ] `npm run build` passes size check

🤖 Generated with [Claude Code](https://claude.com/claude-code)