### PR TITLE
docs(examples): clarify that nav layout requires custom CSS

### DIFF
--- a/examples/index.html
+++ b/examples/index.html
@@ -182,9 +182,9 @@
         <h2>Layout: bring your own CSS</h2>
         <p>
           browser-nano-css does not do layout. The navigation above is a plain
-          <code>&lt;nav&gt;&lt;ul&gt;</code> — browser-nano-css leaves it
-          unstyled. The horizontal flex layout comes from
-          <a href="/examples/style.css">style.css</a>:
+          <code>&lt;nav&gt;&lt;ul&gt;</code> — browser-nano-css adds minimal
+          spacing only, no flex, no positioning. The horizontal flex layout
+          comes from <a href="/examples/style.css">style.css</a>:
         </p>
         <pre><code>/* Your CSS — not part of browser-nano-css */
 nav ul {

--- a/examples/index.html
+++ b/examples/index.html
@@ -28,7 +28,7 @@
         </ul>
       </nav>
       <p class="note">
-        Page layout (flex nav, padding) uses
+        Header and footer padding, and the flex nav layout, come from
         <a href="/examples/style.css">style.css</a>. That CSS is not part of
         browser-nano-css.
       </p>
@@ -181,10 +181,11 @@
       <section id="custom-layout">
         <h2>Layout: bring your own CSS</h2>
         <p>
-          browser-nano-css does not do layout. The navigation above is a plain
+          browser-nano-css does not provide flex or positioning for nav layout.
+          The navigation above is a plain
           <code>&lt;nav&gt;&lt;ul&gt;</code> — browser-nano-css adds minimal
-          spacing only, no flex, no positioning. The horizontal flex layout
-          comes from <a href="/examples/style.css">style.css</a>:
+          spacing only. The horizontal flex layout comes from
+          <a href="/examples/style.css">style.css</a> (simplified example):
         </p>
         <pre><code>/* Your CSS — not part of browser-nano-css */
 nav ul {

--- a/examples/index.html
+++ b/examples/index.html
@@ -24,8 +24,14 @@
           <li><a href="#structure">Structure</a></li>
           <li><a href="#forms">Forms</a></li>
           <li><a href="#table">Table</a></li>
+          <li><a href="#custom-layout">Layout</a></li>
         </ul>
       </nav>
+      <p class="note">
+        Page layout (flex nav, padding) uses
+        <a href="/examples/style.css">style.css</a>. That CSS is not part of
+        browser-nano-css.
+      </p>
     </header>
 
     <main>
@@ -172,6 +178,32 @@
           </tbody>
         </table>
       </section>
+      <section id="custom-layout">
+        <h2>Layout: bring your own CSS</h2>
+        <p>
+          browser-nano-css does not do layout. The navigation above is a plain
+          <code>&lt;nav&gt;&lt;ul&gt;</code> — browser-nano-css leaves it
+          unstyled. The horizontal flex layout comes from
+          <a href="/examples/style.css">style.css</a>:
+        </p>
+        <pre><code>/* Your CSS — not part of browser-nano-css */
+nav ul {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  list-style: none;
+  padding: 0;
+}</code></pre>
+        <p>Without that extra CSS, the same nav looks like this:</p>
+        <nav aria-label="Raw nav example">
+          <ul>
+            <li><a href="#typography">Typography</a></li>
+            <li><a href="#structure">Structure</a></li>
+            <li><a href="#forms">Forms</a></li>
+            <li><a href="#table">Table</a></li>
+          </ul>
+        </nav>
+      </section>
     </main>
 
     <footer>
@@ -181,6 +213,7 @@
           <li><a href="#structure">Structure</a></li>
           <li><a href="#forms">Forms</a></li>
           <li><a href="#table">Table</a></li>
+          <li><a href="#custom-layout">Layout</a></li>
         </ul>
       </nav>
       <small>&copy; 2025 Browser Nano CSS</small>

--- a/examples/style.css
+++ b/examples/style.css
@@ -19,3 +19,8 @@ body > footer {
   border-block-start: 1px solid currentColor;
   margin-block-start: 2rem;
 }
+
+.note {
+  font-size: 0.85em;
+  opacity: 0.75;
+}


### PR DESCRIPTION
## Summary

- Add a visible `.note` paragraph in the header — always rendered, links to `style.css`, says "not part of browser-nano-css"
- Add a new `#custom-layout` section showing the exact flex CSS needed for nav layout, plus a raw unstyled `<nav>` as a before/after comparison
- Add "Layout" link to header and footer navs

## Why

Visitors to the example page see a polished horizontal nav and may assume browser-nano-css provides it. It doesn't — the layout comes from `examples/style.css`. This change makes that boundary visible in the rendered page, not just in source comments.

## Test plan

- [ ] Open example page, confirm note is visible in the header without any interaction
- [ ] Confirm "Layout: bring your own CSS" section shows the flex CSS snippet
- [ ] Confirm raw unstyled nav renders as a vertical list (no flex)
- [ ] `npm test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)