### PR TITLE
chore: change license from MIT to MIT-0

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-MIT License
+MIT No Attribution
 
 Copyright (c) 2025 Matt Murahashi Kenichi
 
@@ -7,10 +7,7 @@ of this software and associated documentation files (the "Software"), to deal
 in the Software without restriction, including without limitation the rights
 to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
+furnished to do so.
 
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,9 @@
+# Unreleased
+
+### Chores
+
+- change license from MIT to MIT-0 (no attribution required)
+
 # [2.1.0](https://github.com/sanemat/browser-nano-css/compare/v2.0.0...v2.1.0) (2026-05-06)
 
 ### Bug Fixes

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "type": "git",
     "url": "git+https://github.com/sanemat/browser-nano-css.git"
   },
-  "license": "MIT",
+  "license": "MIT-0",
   "author": "Matt Murahashi Kenichi",
   "main": "dist/browser-nano.min.css",
   "files": [


### PR DESCRIPTION
## Summary

- Change license from MIT to MIT-0
- MIT-0 removes the attribution requirement — users do not need to include the copyright notice
- Update `LICENSE` file and `package.json` `license` field
- Add note to changelog under `Unreleased`

## Test plan

- [ ] Verify `LICENSE` contains "MIT No Attribution" text
- [ ] Verify `package.json` has `"license": "MIT-0"`
- [ ] Verify changelog has entry under `Unreleased`

🤖 Generated with [Claude Code](https://claude.com/claude-code)