### PR TITLE
docs: update CLAUDE.md to be concise and accurate

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,6 +11,13 @@
 
 ## Constraints
 
-- **999 bytes gzipped limit** — build fails if exceeded
+- **999 bytes gzipped limit** — build fails if exceeded; if we exceed it, cut features, never raise the limit
 - Element-based selectors only (no utility classes); not compatible with CSS purging tools
 - Standard CSS only; targets Chrome, Safari, Firefox
+
+## Philosophy
+
+> Write correct HTML. Get a usable, readable screen on mobile. Handle your own layout. Under 999 bytes.
+
+"Trust the browser" — only for properties we have not touched. Once we declare a property, we own all consequences.
+CSS additions must justify their bytes. See `design.md` for full rationale.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,7 +5,7 @@
 - `npm test` - Format check + HTML validation (primary test)
 - `npm run format` - Auto-fix formatting (run after editing CSS or HTML)
 - `npm run build` - Clean, process CSS, checksums, size check
-- `npm run size:check` - Verify under 2KB gzipped
+- `npm run size:check` - Verify under 999 bytes gzipped
 - `npm run changelog` - Generate changelog (conventional commits)
 - `npm run git:tag` - Create git tag from package.json version
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,73 +1,16 @@
 # CLAUDE.md
 
-This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+## Commands
 
-## Project Overview
+- `npm test` - Format check + HTML validation (primary test)
+- `npm run format` - Auto-fix formatting (run after editing CSS or HTML)
+- `npm run build` - Clean, process CSS, checksums, size check
+- `npm run size:check` - Verify under 2KB gzipped
+- `npm run changelog` - Generate changelog (conventional commits)
+- `npm run git:tag` - Create git tag from package.json version
 
-Browser Nano CSS is a lightweight, mobile-first CSS template that provides clean styles for default HTML elements without requiring extra classes. The project focuses on minimalism, fast loading, and ease of use.
+## Constraints
 
-## Development Commands
-
-### Build and Development
-
-- `npm run build` - Clean and process CSS, then run checksums and size check
-- `npm run dev` - Start development mode with file watching and local server
-- `npm run watch` - Watch CSS files and rebuild on changes
-- `npm run serve` - Start local development server
-
-### CSS Processing
-
-- `npm run process-css` - Process CSS with PostCSS and generate minified output
-- `npm run clean` - Remove all files from dist directory
-
-### Quality and Testing
-
-- `npm test` - Run format checks (this is the primary test command)
-- `npm run format:check` - Check code formatting with Prettier and package.json sorting
-- `npm run format` - Auto-fix formatting issues
-- `npm run size:check` - Verify CSS file is under 2KB gzipped (fails build if exceeded)
-- `npm run size` - Show current gzipped size of CSS file
-
-### Release
-
-- `npm run changelog` - Generate changelog using conventional commits
-- `npm run git:tag` - Create git tag based on package.json version
-
-## Architecture
-
-### Source Structure
-
-- `src/browser-nano.css` - Main CSS source file with design tokens and component styles
-- `postcss.config.js` - PostCSS configuration using cssnano for minification
-- `tools/size.js` - CLI tool for checking gzipped CSS file size (2KB limit)
-
-### Build Process
-
-The build process transforms `src/browser-nano.css` into `dist/browser-nano.min.css` using PostCSS with cssnano for minification. The build automatically generates checksums (SHA256/SHA384) and verifies the file size stays under 2KB gzipped.
-
-### Design Philosophy
-
-- Element-based styling (no utility classes)
-- CSS variables for customization
-- Mobile-first responsive design
-- Size-constrained (under 2KB gzipped)
-- Not compatible with CSS purging tools due to element-based selectors
-
-### Key Constraints
-
-- Must maintain under 2KB gzipped size
-- Uses only standard CSS features for broad browser support
-- Styles apply directly to HTML elements, not classes
-- Target browsers: Chrome, Safari, Firefox (desktop and mobile)
-
-## Development Workflow
-
-### Code Formatting
-
-After editing CSS or HTML files, always run formatting:
-
-```bash
-npm run format
-```
-
-This ensures consistent code style using Prettier and keeps package.json sorted.
+- **999 bytes gzipped limit** — build fails if exceeded
+- Element-based selectors only (no utility classes); not compatible with CSS purging tools
+- Standard CSS only; targets Chrome, Safari, Firefox


### PR DESCRIPTION
## Summary

- Reduce from 74 lines to 24 lines
- Focus on non-obvious information only (what Claude can't infer from code)
- Fix `npm test` description to include HTML validation
- Update size limit from 2KB to 999 bytes (matches `tools/size.js`)
- Add design philosophy: "Trust the browser" principle and the rule to cut features rather than raise the size limit

🤖 Generated with [Claude Code](https://claude.com/claude-code)