### PR TITLE
chore: bump version to 2.1.1 and update changelog

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,8 +1,8 @@
-# Unreleased
+## [2.1.1](https://github.com/sanemat/browser-nano-css/compare/v2.1.0...v2.1.1) (2026-05-06)
 
 ### Chores
 
-- change license from MIT to MIT-0 (no attribution required)
+- change license from MIT to MIT-0 (no attribution required) ([fab6fb1](https://github.com/sanemat/browser-nano-css/commit/fab6fb1))
 
 # [2.1.0](https://github.com/sanemat/browser-nano-css/compare/v2.0.0...v2.1.0) (2026-05-06)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "browser-nano-css",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "CSS template",
   "homepage": "https://github.com/sanemat/browser-nano-css#readme",
   "bugs": {

--- a/readme.md
+++ b/readme.md
@@ -80,7 +80,7 @@ Styles apply directly to HTML elements (`button {}`, not `.btn {}`). PurgeCSS an
 
 ## License
 
-MIT
+MIT-0
 
 ## Design
 


### PR DESCRIPTION
## Summary

- Bump version 2.1.0 → 2.1.1
- Update changelog with license change entry
- Update readme license from MIT to MIT-0

## Changes since v2.1.0

- License changed from MIT to MIT-0 (no attribution required)
- CLAUDE.md streamlined

🤖 Generated with [Claude Code](https://claude.com/claude-code)