### PR TITLE
feat: prevent long text overflow on mobile

### DIFF
--- a/design.md
+++ b/design.md
@@ -103,6 +103,7 @@ Dark mode swaps `--bg` and `--text` via `light-dark()`. `--accent` uses blue in 
 - Line-height: `1.6` — readable on mobile
 - Font-weight: browser defaults only — we do not override `bold`
 - `h4`/`h5`/`h6` floored at `1em` — smaller than body text breaks mobile readability
+- `overflow-wrap: break-word` on `body` — long URLs and words do not cause horizontal scroll on mobile
 
 ---
 

--- a/src/browser-nano.css
+++ b/src/browser-nano.css
@@ -33,6 +33,7 @@ body {
   font-size: var(--font-size-base);
   line-height: 1.6;
   margin: 0;
+  overflow-wrap: break-word;
 }
 
 :where(h1, h2, h3, h4, h5, h6) {


### PR DESCRIPTION
## Summary

- Add `overflow-wrap: break-word` to `body`
- Prevents long URLs and words from causing horizontal scroll on small screens
- Update `design.md` Typography section to document this behavior

## Size

736 bytes gzipped (within 999 byte limit)

Closes #188