### PR TITLE
chore: bump version to 2.2.0 and update changelog

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,9 @@
+# [2.2.0](https://github.com/sanemat/browser-nano-css/compare/v2.1.1...v2.2.0) (2026-05-06)
+
+### Features
+
+- prevent long text overflow on mobile ([de58d10](https://github.com/sanemat/browser-nano-css/commit/de58d104004c2f620e6ded4159633d786841b0bc)), closes [#188](https://github.com/sanemat/browser-nano-css/issues/188)
+
 ## [2.1.1](https://github.com/sanemat/browser-nano-css/compare/v2.1.0...v2.1.1) (2026-05-06)
 
 ### Chores

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "browser-nano-css",
-  "version": "2.1.1",
+  "version": "2.2.0",
   "description": "CSS template",
   "homepage": "https://github.com/sanemat/browser-nano-css#readme",
   "bugs": {


### PR DESCRIPTION
## Summary

- Bump version `2.1.1` → `2.2.0` (feat commit → minor bump)
- Update `changelog.md` with v2.2.0 entry

## Changes since v2.1.1

- feat: prevent long text overflow on mobile ([#188](https://github.com/sanemat/browser-nano-css/issues/188))

## Test plan

- [ ] `npm test` passes
- [ ] `npm run build` passes (under 999 bytes gzipped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)